### PR TITLE
release: add Fluent Bit 5.0.8 notes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,9 +9,9 @@ logo = "/images/logo.svg"
 logo2 = "/images/logo-white.svg"
 footer_logo = "/images/footer-logo.svg"
 copyright = "© 2015-2025 The Fluent Bit Authors. Fluent Bit is a CNCF graduated project under the Fluent organization"
-lastVersion = "v5.0.7"
-releasedOn = "June 5, 2026"
-noteUrl = "announcements/v5.0.7"
+lastVersion = "v5.0.8"
+releasedOn = "June 23, 2026"
+noteUrl = "announcements/v5.0.8"
 
    [menu]
     [[menu.main]]

--- a/content/announcements/_index.md
+++ b/content/announcements/_index.md
@@ -8,4 +8,4 @@ latestVer: true
 ---
 
 
-{{% content "announcements/v5.0/v5.0.7.md" %}}
+{{% content "announcements/v5.0/v5.0.8.md" %}}

--- a/content/announcements/v5.0/_index.md
+++ b/content/announcements/v5.0/_index.md
@@ -6,9 +6,9 @@ url: "/announcements/v5.0/"
 herobg: "/images/hero@2x.jpg"
 latestVer: true
 releaseNotes:
-  heading: "Release Notes v5.0.7"
-  version: "v5.0.7"
-  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.0.7. <br>
+  heading: "Release Notes v5.0.8"
+  version: "v5.0.8"
+  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.0.8. <br>
   For people upgrading from previous versions you must read the Upgrading Notes section of our documentation:
   https://docs.fluentbit.io/manual/5.0/installation/upgrade_notes"
 ---

--- a/content/announcements/v5.0/v5.0.7.md
+++ b/content/announcements/v5.0/v5.0.7.md
@@ -6,7 +6,7 @@ release_date: 2026-06-05
 publishdate: 2026-06-05
 ver: v5.0.7
 herobg: "/images/hero@2x.jpg"
-latestVer: true
+latestVer: false
 ---
 
 ###### KNOWLEDGE BASE

--- a/content/announcements/v5.0/v5.0.8.md
+++ b/content/announcements/v5.0/v5.0.8.md
@@ -1,0 +1,106 @@
+---
+title: 'v5.0.8'
+description: 'Next generation Telemetry Agent for Logs, Metrics and Traces.'
+url: "/announcements/v5.0.8/"
+release_date: 2026-06-23
+publishdate: 2026-06-23
+ver: v5.0.8
+herobg: "/images/hero@2x.jpg"
+latestVer: true
+---
+
+###### KNOWLEDGE BASE
+
+## Release Notes v5.0.8
+
+Fluent Bit is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD, Windows and macOS. We are proud to announce the availability of Fluent Bit v5.0.8.
+
+This maintenance release improves filesystem storage quota enforcement, OTLP JSON metric handling, Windows observability, Tail input recovery, and several cloud and search outputs while adding a new eBPF scheduler trace and broadening regression coverage across production pipelines.
+
+
+### What's new ?
+
+<br>
+
+#### Core
+
+<br>
+
+- storage: improve `storage.total_limit_size` accounting by projecting filesystem chunk growth, using chunkio allocation growth, validating released chunk sizes, and releasing successful chunk routes after delivery
+- opentelemetry: render unset OTLP JSON `AnyValue` fields correctly and fix JSON histogram bounds handling
+- config_format: clean up caller-owned Fluent Bit and YAML configuration objects when parsing fails
+- reload: clean up failed reload attempts after configuration parse errors
+- aws: detect authentication errors in XML responses and harden AWS error reporting when error content is unavailable
+- scheduler: dispose channel events cleanly during scheduler destruction
+- regex: fix a crash when parsing regex literals
+- unicode: use the correct maximum size for Cyrillic character handling
+- packaging: install `libxxhash0` in the builder image and update versioned package metadata for v5.0.8
+- ci: update GitHub Actions dependencies and improve Windows build workflow permissions, OS selection, and WiX installation handling for ARM64 workers
+- tests: expand internal, runtime, and integration coverage for storage quota eviction, successful route release, OTLP JSON conversion, histogram bounds, Elasticsearch and OpenSearch bulk metadata, Loki tenant routing, CloudWatch escaping, Forward protocol validation, Tail aged-file pickup, Windows Event Log, Windows exporter metrics, eBPF scheduler traces, scheduler cleanup, AWS error handling, regex literals, reload failures, and configuration parse cleanup
+
+#### Libraries
+
+<br>
+
+- cmetrics: upgrade the bundled library to v2.1.5 with improved Prometheus decoder and remote-write handling
+
+### Plugins
+
+<br>
+
+- **[eBPF (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/ebpf)**
+  - add a `sched` trace for Linux scheduler observability
+  - improve scheduler trace polling and traverse thread IDs correctly in multithreaded environments
+- **[Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail)**
+  - re-check modified time for files aged out by `ignore_active_older_files` so refreshed files can be picked up from the saved offset
+  - align pause and resume handling for inotify progress checks
+  - fix an out-of-bounds read when empty Docker log messages are unescaped
+- **[Windows Event Log (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog)**
+  - handle structured XML queries as separate subscriptions
+  - add additional NULL checks for safer query and subscription cleanup
+- **[Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics)**
+  - detect CPU architecture at runtime and improve WMI context handling across collection cycles
+  - ensure correct bit width handling on 32-bit environments
+- **[Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node-exporter-metrics)**
+  - include file paths in Linux collector error messages to make missing sensor, filesystem, or permission issues easier to diagnose
+  - fix cleanup ordering in shared node exporter utility handling
+- **[Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch)**
+  - sanitize bulk action metadata for NDJSON requests, including configured IDs, logstash prefixes, and update actions
+- **[OpenSearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch)**
+  - sanitize bulk action metadata for NDJSON requests, including configured IDs, logstash prefixes, index record accessors, and update actions
+- **[Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki)**
+  - route records with `Tenant_Id_Key` more reliably across chunk processing
+- **[CloudWatch Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch)**
+  - escape special characters correctly in log event messages before sending them to CloudWatch Logs
+- **[Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward)**
+  - strengthen length and type validation for HELO and protocol payload handling
+- **[Azure Blob (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob)**
+  - treat successful delete-blob responses with the correct status handling
+- **[Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka)**
+  - add integration coverage for OTLP JSON resource partitioning with small message limits
+- **[OpenTelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry)**
+  - improve OTLP JSON metric rendering for unset values and histogram bounds
+
+{{< contributor-list >}}
+
+#### Contributors
+
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won't be the same and won't be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+
+- [Eduardo Silva Pereira](https://github.com/edsiper)
+- [Hiroshi Hatake](https://github.com/cosmo0920)
+- [Ross Golder](https://github.com/rossigee)
+- [Antônio Franco](https://github.com/antoniomrfranco)
+- [zshuang0316](https://github.com/zshuang0316)
+- [Vaibhav-C-S](https://github.com/Vaibhav-C-S)
+- [saddamr3e](https://github.com/saddamr3e)
+
+{{< /contributor-list >}}
+
+#### Join us
+
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
+
+* Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
+* Slack: CNCF Slack, channel `#fluent-bit` ([https://communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf))
+* Twitter: [@fluentbit](https://twitter.com/fluentbit)


### PR DESCRIPTION
## Summary

- Add the Fluent Bit v5.0.8 release announcement.
- Update the announcements landing page and v5.0 series metadata to point at v5.0.8.
- Bump the site-wide latest version banner metadata from v5.0.7 to v5.0.8.
- Mark v5.0.7 as no longer the latest announcement.

## Notes

The announcement was drafted from the `v5.0.7..v5.0.8` delta in the Fluent Bit repository and follows the existing v5.0 release-note structure.

## Validation

- `hugo`
- `hugo --quiet`
- local checks against `/announcements/v5.0.8/`, `/announcements/`, and `/announcements/v5.0/` with `hugo server -D`
