### PR TITLE
release: add Fluent Bit v5.1.1 announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,9 +9,9 @@ logo = "/images/logo.svg"
 logo2 = "/images/logo-white.svg"
 footer_logo = "/images/footer-logo.svg"
 copyright = "© 2015-2025 The Fluent Bit Authors. Fluent Bit is a CNCF graduated project under the Fluent organization"
-lastVersion = "v5.1.0"
-releasedOn = "August 5, 2026"
-noteUrl = "announcements/v5.1.0"
+lastVersion = "v5.1.1"
+releasedOn = "August 14, 2026"
+noteUrl = "announcements/v5.1.1"
 
    [menu]
     [[menu.main]]

--- a/content/announcements/_index.md
+++ b/content/announcements/_index.md
@@ -8,4 +8,4 @@ latestVer: true
 ---
 
 
-{{% content "announcements/v5.1/v5.1.0.md" %}}
+{{% content "announcements/v5.1/v5.1.1.md" %}}

--- a/content/announcements/v5.1/_index.md
+++ b/content/announcements/v5.1/_index.md
@@ -6,9 +6,9 @@ url: "/announcements/v5.1/"
 herobg: "/images/hero@2x.jpg"
 latestVer: true
 releaseNotes:
-  heading: "Release Notes v5.1.0"
-  version: "v5.1.0"
-  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.1.0. <br>
+  heading: "Release Notes v5.1.1"
+  version: "v5.1.1"
+  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.1.1. <br>
   For people upgrading from previous versions you must read the Upgrading Notes section of our documentation:
   https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes"
 ---

--- a/content/announcements/v5.1/v5.1.0.md
+++ b/content/announcements/v5.1/v5.1.0.md
@@ -6,7 +6,7 @@ release_date: 2026-08-05
 publishdate: 2026-08-05
 ver: v5.1.0
 herobg: "/images/hero@2x.jpg"
-latestVer: true
+latestVer: false
 ---
 
 ###### KNOWLEDGE BASE

--- a/content/announcements/v5.1/v5.1.1.md
+++ b/content/announcements/v5.1/v5.1.1.md
@@ -1,0 +1,90 @@
+---
+title: 'v5.1.1'
+description: 'Next generation Telemetry Agent for Logs, Metrics and Traces.'
+url: "/announcements/v5.1.1/"
+release_date: 2026-08-14
+publishdate: 2026-08-14
+ver: v5.1.1
+herobg: "/images/hero@2x.jpg"
+latestVer: true
+---
+
+###### KNOWLEDGE BASE
+
+## Release Notes v5.1.1
+
+[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of **Fluent Bit v5.1.1**.
+
+For people upgrading from previous versions, please read the Upgrading Notes section of our documentation:
+
+[https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes](https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes)
+
+Fluent Bit v5.1.1 is a maintenance release that improves storage-limit enforcement, retry handling, and output reliability. It also adds timestamp-based destinations to the File output, automatic timestamp extraction for Splunk, and hostname promotion for LogDNA.
+
+The release contains 54 commits since v5.1.0, with fixes and expanded coverage across the engine, storage backlog, networking, outputs, metrics collection, packaging, and test suite.
+
+### What's new ?
+
+<br>
+
+### Core
+
+<br>
+
+- storage: enforce `storage.total_limit_size` correctly for configurations with many outputs and improve visibility when chunks are evicted
+- storage backlog: preserve unroutable chunks on disk so a future configuration can process them
+- engine: reschedule transient chunk-read failures within the configured retry limit, clean up stale tasks, and improve retry-failure accounting
+- networking: invalidate TLS sessions before closing downstream sockets for safer connection cleanup
+- plugin proxy: propagate configuration maps when registering proxy-backed input, output, and custom plugins
+- stream processor: release allocated resources when stream initialization fails
+- encoding: correct SIMD boundary handling for long and percent-containing strings
+- packaging: correct package index links so release artifacts resolve under the expected package paths
+- tests: expand storage-limit, backlog, retry, output, SIMD-boundary, reload, and Windows coverage
+
+### Plugins
+
+<br>
+
+#### Inputs
+
+- **[Node Exporter Metrics](https://docs.fluentbit.io/manual/pipeline/inputs/node-exporter-metrics)**
+  - correct disk statistics metric caching on Linux and macOS to prevent invalid disk metric values
+- **[Storage Backlog](https://docs.fluentbit.io/manual/pipeline/inputs/storage-backlog)**
+  - retain chunks without a matching route and add clearer diagnostics for storage-limit eviction
+
+#### Outputs
+
+- **[File](https://docs.fluentbit.io/manual/pipeline/outputs/file)**
+  - add optional `strftime` placeholders in output paths and filenames, based on each event's UTC timestamp
+  - preserve literal percent characters by keeping timestamp expansion disabled by default
+- **[Splunk](https://docs.fluentbit.io/manual/pipeline/outputs/splunk)**
+  - add `auto_extract_timestamp` so Splunk HTTP Event Collector can derive timestamps from event data
+- **[LogDNA](https://docs.fluentbit.io/manual/pipeline/outputs/logdna)**
+  - promote a record's hostname to the primary hostname field, with the configured hostname as a fallback
+- **[Amazon S3](https://docs.fluentbit.io/manual/pipeline/outputs/s3)**
+  - strengthen concurrent buffer and quarantine accounting, prevent size underflow, and stop repeated retries when storage limits are reached
+
+{{< contributor-list >}}
+
+#### Contributors
+
+On every release, many people contribute through bug reports, troubleshooting, documentation, testing, and code. Without these community contributions, the project would not be in the great shape that it is today. Thank you to everyone who takes part in this journey!
+
+- [Eduardo Silva Pereira](https://github.com/edsiper)
+- [Hiroshi Hatake](https://github.com/cosmo0920)
+- [Anurag Gupta](https://github.com/agup006)
+- [Ilia Petrov](https://github.com/iypetrov)
+- [ku524](https://github.com/ku524)
+- [lecaros](https://github.com/lecaros)
+- [Michael Renner](https://github.com/terrorobe)
+- [Nicolas Gillen](https://github.com/ngillen)
+
+{{< /contributor-list >}}
+
+#### Join us
+
+We want to hear from you. Our community keeps growing, and you can be part of it:
+
+* Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
+* Slack: CNCF Slack, channel `#fluent-bit` ([https://communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf))
+* Twitter: [@fluentbit](https://twitter.com/fluentbit)


### PR DESCRIPTION
## Summary

- add the Fluent Bit v5.1.1 release announcement based on the tagged v5.1.0...v5.1.1 source delta
- highlight storage and retry reliability improvements plus File, Splunk, LogDNA, S3, and Node Exporter Metrics updates
- update the site-wide, announcements, and v5.1-series latest-version metadata
- credit the release contributors identified from commit authors and sign-off trailers

## Impact

Publishes the v5.1.1 maintenance release notes and makes v5.1.1 the latest version shown across fluentbit.io.

## Validation

- `git diff --cached --check`
- `hugo`
- local `hugo server -D` review of `/announcements/v5.1.1/`, `/announcements/`, and `/announcements/v5.1/`

Hugo completed successfully with existing deprecation and taxonomy layout warnings.
