### PR TITLE
fix: resolve incorrect instruqt link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ hero:
    Fluent Bit is a super fast, lightweight, and highly scalable logging, metrics, and traces processor and forwarder. It is the preferred choice for cloud and containerized environments.
   buttons:
     - btnText: TRY NOW
-      btnUrl: "https://play.instruqt.com/Fluent/tracks/fluent-bit-getting-started-101"
+      btnUrl: "https://docs.fluentbit.io/manual/about/resources"
     - btnText: DOWNLOAD NOW
       btnUrl: "https://docs.fluentbit.io/manual/installation/getting-started-with-fluent-bit"
   noteText: Read the notes »


### PR DESCRIPTION
Resolves invalid Instruqt link by forwarding to the docs page for resources instead.

@agup006 @edsiper @lecaros not sure if Instruqt should still work but something else is incorrectly configured?