### PR TITLE
release: add Fluent Bit v5.1.2 announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,9 +9,9 @@ logo = "/images/logo.svg"
 logo2 = "/images/logo-white.svg"
 footer_logo = "/images/footer-logo.svg"
 copyright = "© 2015-2025 The Fluent Bit Authors. Fluent Bit is a CNCF graduated project under the Fluent organization"
-lastVersion = "v5.1.1"
-releasedOn = "August 14, 2026"
-noteUrl = "announcements/v5.1.1"
+lastVersion = "v5.1.2"
+releasedOn = "September 4, 2026"
+noteUrl = "announcements/v5.1.2"
 
    [menu]
     [[menu.main]]

--- a/content/announcements/_index.md
+++ b/content/announcements/_index.md
@@ -8,4 +8,4 @@ latestVer: true
 ---
 
 
-{{% content "announcements/v5.1/v5.1.1.md" %}}
+{{% content "announcements/v5.1/v5.1.2.md" %}}

--- a/content/announcements/v5.1/_index.md
+++ b/content/announcements/v5.1/_index.md
@@ -6,9 +6,9 @@ url: "/announcements/v5.1/"
 herobg: "/images/hero@2x.jpg"
 latestVer: true
 releaseNotes:
-  heading: "Release Notes v5.1.1"
-  version: "v5.1.1"
-  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.1.1. <br>
+  heading: "Release Notes v5.1.2"
+  version: "v5.1.2"
+  text: "Fluent Bit is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of Fluent Bit v5.1.2. <br>
   For people upgrading from previous versions you must read the Upgrading Notes section of our documentation:
   https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes"
 ---

--- a/content/announcements/v5.1/v5.1.1.md
+++ b/content/announcements/v5.1/v5.1.1.md
@@ -6,7 +6,7 @@ release_date: 2026-08-14
 publishdate: 2026-08-14
 ver: v5.1.1
 herobg: "/images/hero@2x.jpg"
-latestVer: true
+latestVer: false
 ---
 
 ###### KNOWLEDGE BASE

--- a/content/announcements/v5.1/v5.1.2.md
+++ b/content/announcements/v5.1/v5.1.2.md
@@ -1,0 +1,122 @@
+---
+title: 'v5.1.2'
+description: 'Next generation Telemetry Agent for Logs, Metrics and Traces.'
+url: "/announcements/v5.1.2/"
+release_date: 2026-09-04
+publishdate: 2026-09-04
+ver: v5.1.2
+herobg: "/images/hero@2x.jpg"
+latestVer: true
+---
+
+###### KNOWLEDGE BASE
+
+## Release Notes v5.1.2
+
+[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Telemetry Agent for Linux, BSD, macOS and Windows. We are proud to announce the availability of **Fluent Bit v5.1.2**.
+
+For people upgrading from previous versions, please read the Upgrading Notes section of our documentation:
+
+[https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes](https://docs.fluentbit.io/manual/5.1/installation/upgrade_notes)
+
+Fluent Bit v5.1.2 is a maintenance release that improves retry isolation, engine lifecycle reliability, metrics ingestion, and storage accounting. It also expands Google Cloud Storage authentication and formatting options, adds built-in JSON multiline parsing, and introduces namespace-aware controls for Systemd and Kubernetes workloads.
+
+The release contains 126 commits since v5.1.1, with fixes and expanded coverage across the engine, configuration and reload paths, metrics processing, cloud outputs, storage, platform integrations, and test suite.
+
+### What's new ?
+
+<br>
+
+### Core
+
+<br>
+
+- engine: improve startup and shutdown coordination, including reliable shutdown when Fluent Bit is embedded as a library
+- output retries: isolate retry payload state by route so Elasticsearch and OpenSearch can retry partial bulk failures without losing successful acknowledgements
+- metrics: ingest queued and Forward metrics contexts atomically and support bounded OpenTelemetry metric batches
+- configuration: validate service properties, honor environment-provided log levels alongside configuration files, and preserve relative parser paths during hot reload
+- multiline: add a built-in JSON parser for multiline JSON objects and validate incomplete boundaries
+- networking: recycle HTTP connections correctly and improve connection cleanup
+- storage and logging: add overflow-safe accounting checks, strengthen log-suppression behavior, and release resources on initialization failures
+- tests: expand engine lifecycle, hot reload, multiline, metrics batching, retry, storage-boundary, platform, and cloud-output coverage
+
+### Libraries
+
+<br>
+
+- cmetrics: upgrade to v2.2.2, including support for batching OpenTelemetry metric encoding by data-point limits
+
+### Plugins
+
+<br>
+
+#### Inputs
+
+- **[Node Exporter Metrics](https://docs.fluentbit.io/manual/pipeline/inputs/node-exporter-metrics)**
+  - add macOS `stat` and thermal-zone metrics, expire stale network metrics, and improve collector boundary handling
+- **[Systemd](https://docs.fluentbit.io/manual/pipeline/inputs/systemd)**
+  - add journal namespace selection when supported by the installed systemd library
+- **[Forward](https://docs.fluentbit.io/manual/pipeline/inputs/forward)**
+  - ingest every metrics context in batched payloads as one atomic operation
+- **[Windows Event Log](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog)**
+  - handle configurations where every missing channel is intentionally ignored without terminating the process
+
+#### Processors & Filters
+
+- **[Kubernetes](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes)**
+  - support namespace-level exclusion with pod-level overrides and reject invalid override values
+- **[Multiline](https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace)**
+  - make the new built-in JSON multiline parser available to the filter and Tail input
+
+#### Outputs
+
+- **Google Cloud Storage**
+  - add Application Default Credentials and Workload Identity Federation authentication
+  - add Parquet compression choices and a `unify_tag` option for buffering multiple tags into one object
+- **[Amazon S3](https://docs.fluentbit.io/manual/pipeline/outputs/s3)**
+  - improve restored-buffer accounting and clean up orphaned or retry-exhausted files
+- **[Elasticsearch](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) and [OpenSearch](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch)**
+  - retry only failed items from partial bulk responses while preserving delivery acknowledgements
+- **[OpenTelemetry](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry)**
+  - split large metric payloads into batches that respect configured data-point limits
+- **[Splunk](https://docs.fluentbit.io/manual/pipeline/outputs/splunk)**
+  - add `time_key` to select a record field for the HTTP Event Collector event timestamp
+- **[Prometheus Remote Write](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write)**
+  - expire metrics that have remained stale for one hour
+- **[Kafka](https://docs.fluentbit.io/manual/pipeline/outputs/kafka)**
+  - preserve infinite shutdown-grace configurations while continuing to honor finite grace periods
+- **[Loki](https://docs.fluentbit.io/manual/pipeline/outputs/loki)**
+  - isolate `remove_keys` accessor caches across plugin instances and improve thread-local cleanup
+- **Azure Blob and Azure Data Explorer**
+  - improve error-path cleanup and prevent authentication tokens from appearing in logs
+
+{{< contributor-list >}}
+
+#### Contributors
+
+On every release, many people contribute through bug reports, troubleshooting, documentation, testing, and code. Without these community contributions, the project would not be in the great shape that it is today. Thank you to everyone who takes part in this journey!
+
+- [Eduardo Silva Pereira](https://github.com/edsiper)
+- [Hiroshi Hatake](https://github.com/cosmo0920)
+- [Anurag Gupta](https://github.com/agup006)
+- [Antonio Santos](https://github.com/antonio)
+- [Arpit Jain](https://github.com/arpitjain099)
+- [balys](https://github.com/balys)
+- [Daniel Beneker](https://github.com/dbeneker)
+- [Gabi Davar](https://github.com/mindw)
+- [Hima Poojitha Sai Sree Myla](https://github.com/himapom)
+- [lecaros](https://github.com/lecaros)
+- [Marco Franssen](https://github.com/marcofranssen)
+- [Pablo Garcia Caceres](https://github.com/MsfPablo)
+- [Tanmaya Panda](https://github.com/tanmaya-panda1)
+- [Uri Sternik](https://github.com/uristernik)
+
+{{< /contributor-list >}}
+
+#### Join us
+
+We want to hear from you. Our community keeps growing, and you can be part of it:
+
+* Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
+* Slack: CNCF Slack, channel `#fluent-bit` ([https://communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf))
+* Twitter: [@fluentbit](https://twitter.com/fluentbit)


### PR DESCRIPTION
## Summary

- add the Fluent Bit v5.1.2 release announcement from the v5.1.1..v5.1.2 source delta
- update the announcements landing pages and latest-version metadata
- include release contributors and mark v5.1.1 as no longer latest

## Validation

- `hugo`
- verified `/announcements/v5.1.2/`, `/announcements/`, and `/announcements/v5.1/` with `hugo server -D`